### PR TITLE
Add synchronized multiple jobs support to client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -105,6 +105,33 @@ class Client
     }
 
     /**
+     * @param array $jobs Array of dmank\gearman\Job, jobs to do
+     * @param int   $priority
+     * @return array
+     */
+    public function executeJobs(array $jobs, $priority = self::PRIORITY_LOW)
+    {
+        $client = $this->getClient();
+
+        $results = [];
+        $client->setCompleteCallback(function($task) use (&$results) {
+            $results[] = $task->data();
+        });
+
+        foreach ($jobs as $job) {
+            if (!is_a($job, Job::class)) {
+                continue;
+            }
+
+            $client->addTask($job->getJobName(), $job->getWorkLoad());
+        }
+
+        $client->runTasks();
+
+        return $results;
+    }
+
+    /**
      * @return \GearmanClient
      */
     private function getClient()

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -3,6 +3,7 @@ namespace tests\dmank\gearman;
 
 use dmank\gearman\Client;
 use dmank\gearman\JobStatus;
+use dmank\gearman\Job;
 use dmank\gearman\Server;
 use dmank\gearman\ServerCollection;
 
@@ -97,6 +98,31 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->setImplementation($this->mockedImplementation);
 
         $client->executeJob('foo', 'bar');
+    }
+
+    public function testExecuteJobs()
+    {
+        $server = new Server();
+        $serverCollection = $this->getMockBuilder('\dmank\gearman\ServerCollection')->getMock();
+        $serverCollection->expects($this->once())
+            ->method('getServers')
+            ->will($this->returnValue(array($server)));
+
+        $job = new Job('JobName', 'WorkLoads');
+        $this->mockedImplementation->expects($this->once())
+            ->method('addTask')
+            ->with($job->getJobName(), $job->getWorkLoad());
+        $this->mockedImplementation->expects($this->once())
+            ->method('runTasks');
+
+        $client = new Client($serverCollection);
+        $client->setImplementation($this->mockedImplementation);
+
+        $jobs = [];
+        $jobs[] = $job;
+        $jobs[] = 'Something can not be accpeted';
+
+        $client->executeJobs($jobs);
     }
 
     public function asyncProvider()


### PR DESCRIPTION
Hello,
I use this library in my project.
But I find it doesn't support "synchronized multiple jobs execution".
So I add a function `executeJobs(array $jobs, $priority)` to fulfill my use case.
