### PR TITLE
fix high cpu usage when gearman queue no job

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -45,14 +45,21 @@ class Worker
      */
     private $killRequested = false;
 
+    /**
+     * @var int
+     */
+    private $runInterval = 0;
+
     public function __construct(
         ServerCollection $servers,
         JobCollection $jobs,
-        EventDispatcherInterface $dispatcher
+        EventDispatcherInterface $dispatcher,
+        $runInterval = 50000
     ) {
         $this->serverCollection = $servers;
         $this->jobs = $jobs;
         $this->dispatcher = $dispatcher;
+        $this->runInterval = $runInterval;
     }
 
     /**
@@ -111,6 +118,7 @@ class Worker
                     );
                 }
 
+                usleep($this->runInterval);
             }
         } catch (NoFunctionGiven $e) {
             throw $e;


### PR DESCRIPTION
hello :D

I found that it's consume many CPU resources when no job in gearman queue.
It run so fast when no any task in queue, so i add the sleep between each run (default 0.05 second).
